### PR TITLE
Improve scrolling to the top header, by scrolling to top of page

### DIFF
--- a/mkdocs_windmill/css/base.css
+++ b/mkdocs_windmill/css/base.css
@@ -22,6 +22,7 @@ body {
 
 .wm-page-content {
   max-width: 700px;
+  position: relative;
 }
 
 .wm-page-top-frame { display: none; }
@@ -315,6 +316,9 @@ body {
 
 .wm-article-nav-buttons {
   margin: 1rem 0;
+  position: absolute;
+  left: 15px;
+  right: 15px;
 }
 
 .wm-page-content img {
@@ -426,6 +430,8 @@ h1 {
     color: #444;
     font-weight: 400;
     font-size: 42px;
+    margin-top: 0;
+    padding-top: 57px
 }
 
 h2, h3, h4, h5, h6 {

--- a/mkdocs_windmill/js/base.js
+++ b/mkdocs_windmill/js/base.js
@@ -78,10 +78,10 @@ function updateIframe(enableForwardNav) {
     currentIframeUrl === targetIframeUrl ? "same" : "replacing");
 
   if (currentIframeUrl !== targetIframeUrl) {
-    $(window).scrollTop(0);
     loc.replace(targetIframeUrl);
     onIframeBeforeLoad(targetIframeUrl);
   }
+  document.body.scrollTop = 0;
 }
 
 /**


### PR DESCRIPTION
To address Issue #4. I fixed it a bit, so that when H1 is at the top, scrolling to it will scroll to the top of the page. @ngawangtrinley: will you be able to test with this pull request and let me know if this is good?