### PR TITLE
Represent license type in Classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,15 @@ setup(
     name="mkdocs-windmill",
     version=VERSION,
     url='https://github.com/gristlabs/mkdocs-windmill',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: MIT License',
+        'Topic :: Documentation',
+        'Topic :: Text Processing',
+    ],
+    install_requires=[
+        'mkdocs',
+    ],
     license='MIT',
     description='MkDocs theme focused on navigation and usability',
     author='Dmitry S',


### PR DESCRIPTION
This design theme is very great for me. I hope that this package will be available with a clear license.

In the Python Developer's Guide, select a license from the Classifier, you have to write the "License" when you can not cover. Please refer to the [PEP 314](https://www.python.org/dev/peps/pep-0314/#license) for more information.

I am pleased that this change will be merged and the next version will be published to PyPI.

Thanks.