### PR TITLE
Include search.html page and update documentation and example.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,11 @@ theme: 'windmill'
 If you cloned Windmill from GitHub:
 
 ``` yaml
-theme_dir: 'mkdocs-windmill/mkdocs_windmill'
+theme:
+  name: null
+  custom_dir: '{INSTALL_DIR}/mkdocs_windmill'
+  search_index_only: true
+  include_search_page: true
 ```
 
 See [Customization](customization.md) for a few extra configuration options

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,11 @@ site_author: 'Dmitry S'
 
 repo_url: https://github.com/gristlabs/mkdocs-windmill
 
-theme: windmill
+theme:
+  name: null
+  custom_dir: mkdocs_windmill
+  search_index_only: true
+  include_search_page: true
 
 pages:
 - Windmill Theme:

--- a/mkdocs_windmill/mkdocs_theme.yml
+++ b/mkdocs_windmill/mkdocs_theme.yml
@@ -1,2 +1,2 @@
 search_index_only: true
-include_search_page: false
+include_search_page: true


### PR DESCRIPTION
The search page needs to be included to allow showing 'all results'.

In documentation, what used to be 'theme_dir' is now 'theme.custom_dir'.

Also include search settings into instructions for using custom_dir,
since theme's mkdocs_theme.yml is ignored in that case (see
https://github.com/mkdocs/mkdocs/issues/1316#issuecomment-339014381)