### PR TITLE
Set version prefix 'v' in mkdocs.yml for more flexible

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,4 +29,4 @@ markdown_extensions:
 
 extra:
   history_buttons: false
-  version: 1.0.1
+  version: v1.0.1

--- a/mkdocs_windmill/topbar.html
+++ b/mkdocs_windmill/topbar.html
@@ -42,7 +42,7 @@
       <div class="wm-top-title">
         {{ config.site_name }}<br>
         {% if config.extra.version %}
-          <span class="wm-top-version">v{{ config.extra.version }}</span>
+          <span class="wm-top-version">{{ config.extra.version }}</span>
         {% endif %}
       </div>
     </a>


### PR DESCRIPTION
Thanks for this awesome theme,
the navigation bar with iframe is very helpful to me.

we use CI to auto replace the version with current branch name for build a documentation for specific branch or environment.

for example:

1. `extra.version = master`

![image](https://user-images.githubusercontent.com/5071526/60672055-0d37d280-9ea7-11e9-883b-ce3f5b9cc5a0.png)

2. `extra.version = staging`


![image](https://user-images.githubusercontent.com/5071526/60671997-f0030400-9ea6-11e9-8c0f-91c389720fce.png)


3. `extra.version = develop`

![image](https://user-images.githubusercontent.com/5071526/60671951-d9f54380-9ea6-11e9-8aeb-ce292c550bac.png)

The version at top bar is `vmaster`, `vstaging` or `vdevelop` with a little weird,
set a fixed version prefix `v` in HTML template is not flexible,
so just move it into mkdocs.yml from HTML template.