### PR TITLE
Fix footer alignment

### DIFF
--- a/mkdocs_windmill/base.html
+++ b/mkdocs_windmill/base.html
@@ -137,7 +137,7 @@ if (is_top_frame) { $('body').addClass('wm-top-page'); }
   {%- endif %}
 </div>
 
-<footer class="col-md-12 wm-page-content">
+<footer class="container-fluid wm-page-content">
 {%- block footer %}
   {%- block repo %}
     {%- if page and page.edit_url %}


### PR DESCRIPTION
Make its classes consistent with its sibling so that both content containers are centre-aligned with the HTML body.

Before:

![image](https://user-images.githubusercontent.com/5075438/72898572-60159200-3cf2-11ea-8fe4-d0d94fd4055e.png)

After:

![image](https://user-images.githubusercontent.com/5075438/72898663-85a29b80-3cf2-11ea-9bdb-9ea363519ba9.png)
