### PR TITLE
Remove the #_top anchor for the first element

### DIFF
--- a/mkdocs_windmill/base.html
+++ b/mkdocs_windmill/base.html
@@ -54,7 +54,7 @@
         {# Include the first two levels of TOC data as a JS object, to be rendered in top frame #}
         var pageToc = [
         {%- for item in page.toc %}
-          {title: {{ item.title|tojson }}, url: {{ ('#_top' if loop.first else item.url)|tojson }}, children: [
+          {title: {{ item.title|tojson }}, url: {{ (item.url)|tojson }}, children: [
             {%- for item in item.children %}
               {title: {{ item.title|tojson }}, url: {{ item.url|tojson }} },
             {%- endfor %}


### PR DESCRIPTION
may the first element in the list isn't at the top of the page, so I
change that to match to the element anchor